### PR TITLE
Omit date selection field for non time based searches

### DIFF
--- a/htdocs/assets/js/views/searches/search.js
+++ b/htdocs/assets/js/views/searches/search.js
@@ -529,6 +529,7 @@ define(function(require) {
                 no_freq: this.no_freq,
                 has_sources: _.isArray(sources),
                 host: Data.Host,
+                is_time_based: Search.Data().TimeBased[this.model.get('type')]
             });
             // Render any additional content.
             vars.addn_fields_a = this.addnFieldsATpl(vars);

--- a/htdocs/assets/templates/searches/search.html
+++ b/htdocs/assets/templates/searches/search.html
@@ -237,18 +237,22 @@
             <button id="test-button" type="button" class="btn btn-info">
               <span class="glyphicon glyphicon-list-alt"></span> Test
             </button>
+            {{#if is_time_based}}
             <button id="custom-test-button" type="button" class="btn btn-info">
               <span class="glyphicon glyphicon-wrench"></span>
             </button>
+            {{/if}}
           </div>
           {{#unless new_search}}
           <div class="btn-group">
             <button id="execute-button" type="button" class="btn btn-primary">
               <span class="glyphicon glyphicon-play"></span> Execute
             </button>
+            {{#if is_time_based}}
             <button id="custom-execute-button" type="button" class="btn btn-primary">
               <span class="glyphicon glyphicon-wrench"></span>
             </button>
+            {{/if}}
           </div>
           {{/unless}}
           {{#if new_search}}


### PR DESCRIPTION
Hello guys!

It will omit the date select field for non-time based searches.

The HTTP Search (non-time based) will look like this:
![image](https://user-images.githubusercontent.com/1084316/32196202-0215bbe8-bda7-11e7-8eee-7da4baca60f8.png)

The ECL Search will look like as before:
![image](https://user-images.githubusercontent.com/1084316/32196241-1fd9202a-bda7-11e7-959b-dcdd7094b38e.png)

This PR's closes #114.